### PR TITLE
Fixing Speech not avalible on some devices

### DIFF
--- a/app/src/main/java/me/proton/android/lumo/speech/SpeechRecognitionManager.kt
+++ b/app/src/main/java/me/proton/android/lumo/speech/SpeechRecognitionManager.kt
@@ -56,9 +56,12 @@ class SpeechRecognitionManager(private val context: Context) {
 
     /**
      * Checks if speech recognition is available on the device
+     * Returns true if the SpeechRecognizer was successfully initialized
      */
     fun isSpeechRecognitionAvailable(): Boolean {
-        return SpeechRecognizer.isRecognitionAvailable(context)
+        // Instead of relying on the system check which can be unreliable,
+        // check if we successfully initialized the SpeechRecognizer
+        return speechRecognizer != null
     }
 
     /**
@@ -76,12 +79,15 @@ class SpeechRecognitionManager(private val context: Context) {
      * Initializes the speech recognizer
      */
     private fun initializeSpeechRecognizer() {
-        if (SpeechRecognizer.isRecognitionAvailable(context)) {
+        try {
+            // Always attempt to create the SpeechRecognizer
+            // The availability check can be unreliable on some devices
             speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context)
             setupSpeechRecognizerListener()
             Log.d(TAG, "SpeechRecognizer initialized.")
-        } else {
-            Log.e(TAG, "SpeechRecognizer not available on this device.")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to initialize SpeechRecognizer", e)
+            speechRecognizer = null
         }
     }
 


### PR DESCRIPTION
Since some devices don't use GMS or can have issue with the speech detection used, I've modified the function to make it launch a speech attempt and if it fails it will return the error.

This approach allows any device with any speech provider to work properly even without GMS

It would be nice to change on the web end the speech recognition treated by Google since not everyone use Google Voice Inupt (even tho a lot do.) But maybe put System voice input or something like that.